### PR TITLE
Append onto existing notification

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -15,6 +15,7 @@ RDoc[http://rdoc.info/projects/splattael/libnotify]
     notify.body = "hello"
     notify.timeout = 1.5        # 1.5 (s), 1000 (ms), "2", nil, false
     notify.urgency = :critical  # :low, :normal, :critical
+    notify.append = false       # default true - append onto existing notification
     notify.icon_path = "/usr/share/icons/gnome/scalable/emblems/emblem-default.svg"
   end
   n.show!

--- a/lib/libnotify.rb
+++ b/lib/libnotify.rb
@@ -20,7 +20,7 @@ module Libnotify
   #     notify.icon_path = "/usr/share/icons/gnome/scalable/emblems/emblem-default.svg"
   #   end
   #   n.show!
-  # 
+  #
   # @example Mixed syntax
   #   Libnotify.new(options) do |n|
   #     n.timeout = 1.5     # overrides :timeout in options
@@ -77,6 +77,7 @@ module Libnotify
     attach_function :notify_notification_new, [:string, :string, :string, :pointer], :pointer
     attach_function :notify_notification_set_urgency, [:pointer, :urgency], :void
     attach_function :notify_notification_set_timeout, [:pointer, :long], :void
+    attach_function :notify_notification_set_hint_string, [:pointer, :string, :string], :void
     attach_function :notify_notification_show, [:pointer, :pointer], :bool
   end
 
@@ -84,7 +85,7 @@ module Libnotify
     include FFI
 
     attr_reader :timeout
-    attr_accessor :summary, :body, :icon_path, :urgency
+    attr_accessor :summary, :body, :icon_path, :urgency, :append
 
     # Creates a notification object.
     #
@@ -99,6 +100,7 @@ module Libnotify
       self.summary = self.body = ' '
       self.urgency = :normal
       self.timeout = nil
+      self.append = true
     end
     private :set_defaults
 
@@ -110,6 +112,10 @@ module Libnotify
       notify = notify_notification_new(summary, body, icon_path, nil)
       notify_notification_set_urgency(notify, urgency)
       notify_notification_set_timeout(notify, timeout || -1)
+      if append
+        notify_notification_set_hint_string(notify, "x-canonical-append", "")
+        notify_notification_set_hint_string(notify, "append", "")
+      end
       notify_notification_show(notify, nil)
     end
 

--- a/test/test_libnotify.rb
+++ b/test/test_libnotify.rb
@@ -27,6 +27,7 @@ context Libnotify::API do
     asserts("urgency is :normal") { topic.urgency }.equals(:normal)
     asserts("timeout is nil") { topic.timeout }.nil
     asserts("icon_path is nil") { topic.icon_path }.nil
+    asserts("append is true") { topic.append }.equals(true)
   end
 
   context "with options and block" do
@@ -34,12 +35,14 @@ context Libnotify::API do
       topic.new(:summary => "hello", :body => "body", :invalid_option => 23) do |n|
         n.body = "overwritten"
         n.icon_path = "/path/to/icon"
+        n.append = false
       end
     end
 
     asserts("summary is set") { topic.summary }.equals("hello")
     asserts("body was overwritten by block") { topic.body }.equals("overwritten")
     asserts("icon_path set") { topic.icon_path }.equals("/path/to/icon")
+    asserts("append is set") { topic.append }.equals(false)
   end
 
   context "timeout=" do


### PR DESCRIPTION
How's it going? 

Ubuntu has the really obnoxious default behavior of only showing one notification at a time, with a 10 second timeout, if you notify more than once or twice, it takes way too long to see the output.

This commit makes it so that the output gets concatenated onto the existing notification.

I assumed that most people who are using this would be ubuntu users, so I made the default true, but that'd be easy to change.

Thanks for writing this piece of software!

-Dennis
