### PR TITLE
New config option: "transient"

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -18,6 +18,7 @@ http://github.com/splattael/libnotify/raw/master/libnotify.png
     notify.timeout    = 1.5         # 1.5 (s), 1000 (ms), "2", nil, false
     notify.urgency    = :critical   # :low, :normal, :critical
     notify.append     = false       # default true - append onto existing notification
+    notify.transient  = true        # default false - keep the notifications around after display
     notify.icon_path  = "/usr/share/icons/gnome/scalable/emblems/emblem-default.svg"
   end
   n.show!

--- a/lib/libnotify/api.rb
+++ b/lib/libnotify/api.rb
@@ -6,7 +6,7 @@ module Libnotify
     include FFI
 
     attr_reader :timeout, :icon_path
-    attr_accessor :summary, :body, :urgency, :append
+    attr_accessor :summary, :body, :urgency, :append, :transient
 
     class << self
       # List of globs to icons
@@ -49,6 +49,7 @@ module Libnotify
       self.urgency = :normal
       self.timeout = nil
       self.append = true
+      self.transient = false
     end
     private :set_defaults
 
@@ -64,9 +65,12 @@ module Libnotify
         notify_notification_set_hint_string(notify, "x-canonical-append", "")
         notify_notification_set_hint_string(notify, "append", "")
       end
+      if transient
+        notify_notification_set_hint_uint32(notify, "transient", 1)
+      end
       notify_notification_show(notify, nil)
     ensure
-      notify_notification_clear_hints(notify) if append
+      notify_notification_clear_hints(notify) if (append || transient)
     end
 
     # @todo Simplify timeout=

--- a/lib/libnotify/ffi.rb
+++ b/lib/libnotify/ffi.rb
@@ -25,6 +25,7 @@ module Libnotify
       attach_function :notify_notification_set_urgency,     [:pointer, :int],                       :void
       attach_function :notify_notification_set_timeout,     [:pointer, :long],                      :void
       attach_function :notify_notification_set_hint_string, [:pointer, :string, :string],           :void
+      attach_function :notify_notification_set_hint_uint32, [:pointer, :string, :int],              :void
       attach_function :notify_notification_clear_hints,     [:pointer],                             :void
       attach_function :notify_notification_show,            [:pointer, :pointer],                   :bool
     end

--- a/test/test_libnotify.rb
+++ b/test/test_libnotify.rb
@@ -34,6 +34,7 @@ class TestLibnotifyAPI < MiniTest::Unit::TestCase
     assert_nil            libnotify.timeout
     assert_nil            libnotify.icon_path
     assert                libnotify.append
+    assert               !libnotify.transient
   end
 
   def test_with_options_and_block
@@ -41,12 +42,14 @@ class TestLibnotifyAPI < MiniTest::Unit::TestCase
       n.body      = "overwritten"
       n.icon_path = "/path/to/icon"
       n.append    = false
+      n.transient = true
     end
 
     assert_equal "hello",         libnotify.summary
     assert_equal "overwritten",   libnotify.body
     assert_equal "/path/to/icon", libnotify.icon_path
     assert                       !libnotify.append
+    assert                        libnotify.transient
   end
 
   def test_timeout_setter


### PR DESCRIPTION
This will cause the Gnome 3 system notification tray to not keep
libnotify output around forever but rather display them once and forget
about them. This new feature is switch off by default, not to cause any
trouble to existing users.
