### PR TITLE
FFI updated to 1.0.10 to counter warnings

### DIFF
--- a/libnotify.gemspec
+++ b/libnotify.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   if needs_ffi
-    s.add_runtime_dependency      'ffi',          '= 1.0.9'
+    s.add_runtime_dependency      'ffi',          '= 1.0.10'
   end
 
   s.add_development_dependency  'minitest'


### PR DESCRIPTION
I've updated the gemspec to use FFI 1.0.10 to counter warnings in Ruby 1.9.3, existing tests are all passing.
