### PR TITLE
Make gtkmm optional

### DIFF
--- a/lib/libnotify/ffi.rb
+++ b/lib/libnotify/ffi.rb
@@ -5,15 +5,24 @@ module Libnotify
     extend ::FFI::Library
 
     def self.included(base)
-      # Workaround for "half-linked" libnotify.so. Does not work on rubinius (no ffi_lib_flags there)!
-      # See: https://bugzilla.redhat.com/show_bug.cgi?id=626852
-      ffi_lib_flags :lazy, :local, :global if respond_to?(:ffi_lib_flags)
-      ffi_lib %w[libgtk-x11-2.0 libgtk-x11-2.0.so.0 libgtk-x11-2.0.so libgtk-3 libgtk-3.so.0 libgtk-3.so],
-              %w[libgtkmm-2.4 libgtkmm-2.4.so.1 libgtkmm-2.4.so libgtkmm-3.0 libgtkmm-3.0.so.1 libgtkmm-3.0.so],
-              %w[libnotify libnotify.so.4 libnotify.so.3 libnotify.so.2 libnotify.so.1 libnotify.so]
+      load_libs
       attach_functions!
     rescue LoadError => e
       warn e.message
+    end
+
+    def self.load_libs
+      libnotify_libs = %w[libnotify libnotify.so.4 libnotify.so.3 libnotify.so.2 libnotify.so.1 libnotify.so]
+
+      # Workaround for "half-linked" libnotify.so. Does not work on rubinius (no ffi_lib_flags there)!
+      # See: https://bugzilla.redhat.com/show_bug.cgi?id=626852
+      ffi_lib_flags :lazy, :local, :global if respond_to?(:ffi_lib_flags)
+      ffi_lib libnotify_libs
+
+    rescue LoadError
+      ffi_lib %w[libgtk-x11-2.0 libgtk-x11-2.0.so.0 libgtk-x11-2.0.so libgtk-3 libgtk-3.so.0 libgtk-3.so],
+              %w[libgtkmm-2.4 libgtkmm-2.4.so.1 libgtkmm-2.4.so libgtkmm-3.0 libgtkmm-3.0.so.1 libgtkmm-3.0.so],
+              libnotify_libs
     end
 
     URGENCY = [ :low, :normal, :critical ]


### PR DESCRIPTION
This removes the mandatory dependency on gtkmm. I understand that libnotify is provided half-linked in some distributions, as described in  #4. However, adding a hard dependency gtkmm when it's not always needed is not the best approach. It makes this gem unusable on Arch Linux without having to install an unnecessary library.

The included changeset attempts to load libnotify on its own. If that fails, then gtk and gtkmm will be loaded in attempt to resolve the dependency.
