### PR TITLE
require only 'libnotify/version' in gemspec

### DIFF
--- a/libnotify.gemspec
+++ b/libnotify.gemspec
@@ -1,6 +1,6 @@
 # -*- encoding: utf-8 -*-
 $:.push File.expand_path("../lib", __FILE__)
-require "libnotify"
+require "libnotify/version"
 
 platform = Gem::Platform::RUBY
 needs_ffi = true


### PR DESCRIPTION
The gemspec was requiring in 'libnotify' which loads 'libnotify/api' and
finally 'libnotify/ffi'. Because 'libnotify/ffi' requires 'ffi' the gem,
if ffi is not yet available (ie. not in global gems), then reading
of the gemspec will fail.

This changeset requires in only libnotify/version, which has no external
dependencies and will allow for a clean bundle install.
