### PR TITLE
Fixed memory leak

### DIFF
--- a/lib/libnotify/api.rb
+++ b/lib/libnotify/api.rb
@@ -50,7 +50,8 @@ module Libnotify
     # @see Libnotify.show
     def show!
       notify_init(app_name) or raise "notify_init failed"
-      @notification = notify_notification_new(summary, body, icon_path, nil)
+      raw_ptr = notify_notification_new(summary, body, icon_path, nil)
+      @notification = ::FFI::AutoPointer.new(raw_ptr, method(:g_object_unref))
       show
     end
 

--- a/lib/libnotify/ffi.rb
+++ b/lib/libnotify/ffi.rb
@@ -40,6 +40,7 @@ module Libnotify
       attach_function :notify_notification_clear_hints,     [:pointer],                             :void
       attach_function :notify_notification_show,            [:pointer, :pointer],                   :bool
       attach_function :notify_notification_close,           [:pointer, :pointer],                   :bool
+      attach_function :g_object_unref,                      [:pointer],                             :void
     end
 
     def method_missing(method, *args, &block) # :nodoc:


### PR DESCRIPTION
Call to notify_notification_new in Libnotify::API#show! allocates memory on native heap, ownership passed to ruby via pointer, stored in @notification instance var. Leak occurs when Libnotify::API instance goes out of scope, native memory is not freed.

Solution is to wrap the pointer returned by notify_notification_new in an AutoPointer, which calls the native destructor, g_object_unref, when the Libnotify::API instance is GCd.


