### PR TITLE
Uses Integer instead of Fixnum to avoid deprecation warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rvm:
   - 2.1
   - 2.2.4
   - 2.3.0
+  - 2.4.0
   - ruby-head
   - jruby
   - jruby-head

--- a/lib/libnotify/api.rb
+++ b/lib/libnotify/api.rb
@@ -86,7 +86,7 @@ module Libnotify
       @timeout = case timeout
       when Float
         (timeout * 1000).to_i
-      when Fixnum
+      when Integer
         if timeout >= 100 # assume miliseconds
           timeout
         else


### PR DESCRIPTION
Since Ruby 2.4, Fixnum and Bignum have been deprecated and unified into Integer. Using libnotify on 2.4 would trigger this warning:
```
constant ::Fixnum is deprecated
```
This small change removes the warning by using Integer.

I tested locally and then added 2.4.0 to travis config and [confirmed the build still passes](https://travis-ci.org/picandocodigo/libnotify).

More info: https://bugs.ruby-lang.org/issues/12005