### PR TITLE
Document usage of app_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Libnotify.show(:body => "hello", :summary => "world", :timeout => 2.5)
 require 'libnotify'
 
 n = Libnotify.new do |notify|
+  notify.app_name   = "My App"
   notify.summary    = "hello"
   notify.body       = "world"
   notify.timeout    = 1.5         # 1.5 (s), 1000 (ms), "2", nil, false


### PR DESCRIPTION
The option to set the application name was introduced in f8b704733881ffffdd3ab111664ef78b060055e3 but wasn't documented on the README.

Also, I'm not sure if Travis CI is still working for this repository. But the tests run with Ruby MRI 3.3, 3.4, 4.0, JRuby 9.3, JRuby 9.4, JRuby 10.0 and TruffleRuby.

[I tested with GitHub Actions on a branch](https://github.com/picandocodigo/libnotify/actions/runs/26215223706).